### PR TITLE
send the modified options but dont change field

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -41,12 +41,12 @@ export class GenericDatasource {
   }
 
   annotationQuery(options) {
-    options.annotation.query = this.templateSrv.replace(options.annotation.query);
+    tmpltOptions = this.templateSrv.replace(options.annotation.query);
 
     return this.backendSrv.datasourceRequest({
       url: this.url + '/annotations',
       method: 'POST',
-      data: options
+      data: tmpltOptions
     }).then(result => {
       return result.data;
     });


### PR DESCRIPTION
This line is causing the query field to be updated with the template values.

```
options.annotation.query = this.templateSrv.replace(options.annotation.query);
```

we don't want to change the query field. just use the replaced values in the POST data.
now we just store the replaced query into a variable and POST that.

sry. I don't know how to build this in order to update the dist packages.

feel free to change the variable name if. didn't know if there was a standard or something.