### PR TITLE
Allow to type long queries in editor mode

### DIFF
--- a/spec/datasource_spec.js
+++ b/spec/datasource_spec.js
@@ -14,7 +14,7 @@ describe('GenericDatasource', function() {
 
     it('should return an empty array when no targets are set', function(done) {
         ctx.ds.query({targets: []}).then(function(result) {
-            expect(result).to.have.length(0);
+            expect(result.data).to.have.length(0);
             done();
         });
     });

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -14,9 +14,10 @@ export class GenericDatasource {
   // Called once per panel (graph)
   query(options) {
     var query = this.buildQueryParameters(options);
+    query.targets = query.targets.filter(t => !t.hide);
 
     if (query.targets.length <= 0) {
-      return this.q.when([]);
+      return this.q.when({data: []});
     }
 
     return this.backendSrv.datasourceRequest({
@@ -78,7 +79,8 @@ export class GenericDatasource {
     var targets = _.map(options.targets, target => {
       return {
         target: this.templateSrv.replace(target.target),
-        refId: target.refId
+        refId: target.refId,
+        hide: target.hide
       };
     });
 

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,9 +1,9 @@
 <query-editor-row query-ctrl="ctrl" class="generic-datasource-query-row" has-text-edit-mode="true">
-  <div class="gf-form" ng-if="ctrl.target.customQuery">
+  <div class="gf-form" ng-if="ctrl.target.rawQuery">
     <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()" />
   </div>
 
-  <div ng-if="!ctrl.target.customQuery">
+  <div ng-if="!ctrl.target.rawQuery">
     <div class="gf-form">
       <metric-segment-model property="ctrl.target.target" get-options="ctrl.getOptions()" on-change="ctrl.onChangeInternal()"
         css-class="tight-form-item-xxlarge"></metric-segment-model>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,7 +1,12 @@
-<query-editor-row query-ctrl="ctrl" class="generic-datasource-query-row">
-	<div class="gf-form-inline">
-		<div class="gf-form">
-      <metric-segment-model property="ctrl.target.target" get-options="ctrl.getOptions()" on-change="ctrl.onChangeInternal()" css-class="tight-form-item-xxlarge"></metric-segment-model>
-		</div>
-	</div>
+<query-editor-row query-ctrl="ctrl" class="generic-datasource-query-row" has-text-edit-mode="true">
+  <div class="gf-form" ng-if="ctrl.target.customQuery">
+    <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()" />
+  </div>
+
+  <div ng-if="!ctrl.target.customQuery">
+    <div class="gf-form">
+      <metric-segment-model property="ctrl.target.target" get-options="ctrl.getOptions()" on-change="ctrl.onChangeInternal()"
+        css-class="tight-form-item-xxlarge"></metric-segment-model>
+    </div>
+  </div>
 </query-editor-row>

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -17,6 +17,10 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
       // Options have to be transformed by uiSegmentSrv to be usable by metric-segment-model directive
   }
 
+  toggleEditorMode() {
+    this.target.customQuery = !this.target.customQuery;
+  }
+
   onChangeInternal() {
     this.panelCtrl.refresh(); // Asks the panel to refresh data.
   }

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -18,7 +18,7 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
   }
 
   toggleEditorMode() {
-    this.target.customQuery = !this.target.customQuery;
+    this.target.rawQuery = !this.target.rawQuery;
   }
 
   onChangeInternal() {


### PR DESCRIPTION
To be able to send complex queries to the datasource, I propose to add an editor mode (like in the influxdb datasource).

It will be helpful when you have to type a mongodb query and you want to send it directly to the datasource, instead of selecting a metric.

Here a demo of the editor mode :
![editor-mode](https://cloud.githubusercontent.com/assets/2076632/16225033/0de2bc20-37a5-11e6-9980-1a05196c097d.gif)

This PR fix also the handling of the `hide` attribute of each targets.