### PR TITLE
Added support for template variable queries

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -120,6 +120,7 @@ System.register(['lodash'], function (_export, _context) {
           key: 'mapToTextValue',
           value: function mapToTextValue(result) {
             return _.map(result.data, function (d, i) {
+              if (d && d.text && d.value) return { text: d.text, value: d.value }
               return { text: d, value: i };
             });
           }

--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -104,8 +104,9 @@ System.register(['lodash'], function (_export, _context) {
         }, {
           key: 'metricFindQuery',
           value: function metricFindQuery(options) {
+            var target = typeof (options) == "string" ? options : options.target;
             var interpolated = {
-              target: this.templateSrv.replace(options.target, null, 'regex')
+                target: this.templateSrv.replace(target, null, 'regex')
             };
 
             return this.backendSrv.datasourceRequest({

--- a/spec/datasource_spec.js
+++ b/spec/datasource_spec.js
@@ -45,4 +45,203 @@ describe('GenericDatasource', function() {
             done();
         });
     });
+
+    it ('should return the metric results when a target is null', function(done) {
+        ctx.backendSrv.datasourceRequest = function(request) {
+            return ctx.$q.when({
+                _request: request,
+                data: [
+                    "metric_0",
+                    "metric_1",
+                    "metric_2",
+                ]
+            });
+        };
+
+        ctx.templateSrv.replace = function(data) {
+            return data;
+        }
+
+        ctx.ds.metricFindQuery({target: null}).then(function(result) {
+            expect(result).to.have.length(3);
+            expect(result[0].text).to.equal('metric_0');
+            expect(result[0].value).to.equal(0);
+            expect(result[1].text).to.equal('metric_1');
+            expect(result[1].value).to.equal(1);
+            expect(result[2].text).to.equal('metric_2');
+            expect(result[2].value).to.equal(2);
+            done();
+        });
+    });
+
+    it ('should return the metric target results when a target is set', function(done) {
+        ctx.backendSrv.datasourceRequest = function(request) {
+            var target = request.data.target;
+            var result = [target + "_0", target + "_1", target + "_2"];
+
+            return ctx.$q.when({
+                _request: request,
+                data: result
+            });
+        };
+
+        ctx.templateSrv.replace = function(data) {
+            return data;
+        }
+
+        ctx.ds.metricFindQuery({target: 'search'}).then(function(result) {
+            expect(result).to.have.length(3);
+            expect(result[0].text).to.equal('search_0');
+            expect(result[0].value).to.equal(0);
+            expect(result[1].text).to.equal('search_1');
+            expect(result[1].value).to.equal(1);
+            expect(result[2].text).to.equal('search_2');
+            expect(result[2].value).to.equal(2);
+            done();
+        });
+    });
+
+    it ('should return the metric results when the target is an empty string', function(done) {
+        ctx.backendSrv.datasourceRequest = function(request) {
+            return ctx.$q.when({
+                _request: request,
+                data: [
+                    "metric_0",
+                    "metric_1",
+                    "metric_2",
+                ]
+            });
+        };
+
+        ctx.templateSrv.replace = function(data) {
+            return data;
+        }
+
+        ctx.ds.metricFindQuery({target: ''}).then(function(result) {
+            expect(result).to.have.length(3);
+            expect(result[0].text).to.equal('metric_0');
+            expect(result[0].value).to.equal(0);
+            expect(result[1].text).to.equal('metric_1');
+            expect(result[1].value).to.equal(1);
+            expect(result[2].text).to.equal('metric_2');
+            expect(result[2].value).to.equal(2);
+            done();
+        });
+    });
+
+    it ('should return the metric results when the args are an empty object', function(done) {
+        ctx.backendSrv.datasourceRequest = function(request) {
+            return ctx.$q.when({
+                _request: request,
+                data: [
+                    "metric_0",
+                    "metric_1",
+                    "metric_2",
+                ]
+            });
+        };
+
+        ctx.templateSrv.replace = function(data) {
+            return data;
+        }
+
+        ctx.ds.metricFindQuery({}).then(function(result) {
+            expect(result).to.have.length(3);
+            expect(result[0].text).to.equal('metric_0');
+            expect(result[0].value).to.equal(0);
+            expect(result[1].text).to.equal('metric_1');
+            expect(result[1].value).to.equal(1);
+            expect(result[2].text).to.equal('metric_2');
+            expect(result[2].value).to.equal(2);
+            done();
+        });
+    });
+
+    it ('should throw error when args are undefined', function(done) {
+        global.assert.throw(ctx.ds.metricFindQuery, Error, "Cannot read property 'target' of undefined");
+        done();
+    });
+
+    it ('should throw error when args are null', function(done) {
+        global.assert.throw(function() { ctx.ds.metricFindQuery(null); }, Error, "Cannot read property 'target' of null");
+        done();
+    });
+
+    it ('should return the metric target results when the args are a string', function(done) {
+        ctx.backendSrv.datasourceRequest = function(request) {
+            var target = request.data.target;
+            var result = [target + "_0", target + "_1", target + "_2"];
+
+            return ctx.$q.when({
+                _request: request,
+                data: result
+            });
+        };
+
+        ctx.templateSrv.replace = function(data) {
+            return data;
+        }
+
+        ctx.ds.metricFindQuery('search').then(function(result) {
+            expect(result).to.have.length(3);
+            expect(result[0].text).to.equal('search_0');
+            expect(result[0].value).to.equal(0);
+            expect(result[1].text).to.equal('search_1');
+            expect(result[1].value).to.equal(1);
+            expect(result[2].text).to.equal('search_2');
+            expect(result[2].value).to.equal(2);
+            done();
+        });
+    });
+
+    it ('should return data as text and index as value', function(done) {
+        var result = ctx.ds.mapToTextValue({data: ["zero", "one", "two"]});
+
+        expect(result).to.have.length(3);
+        expect(result[0].text).to.equal('zero');
+        expect(result[0].value).to.equal(0);
+        expect(result[1].text).to.equal('one');
+        expect(result[1].value).to.equal(1);
+        expect(result[2].text).to.equal('two');
+        expect(result[2].value).to.equal(2);
+        done();
+    });
+
+    it ('should return text as text and value as value', function(done) {
+        var data = [
+            {text: "zero", value: "value_0"},
+            {text: "one", value: "value_1"},
+            {text: "two", value: "value_2"},
+        ];
+
+        var result = ctx.ds.mapToTextValue({data: data});
+
+        expect(result).to.have.length(3);
+        expect(result[0].text).to.equal('zero');
+        expect(result[0].value).to.equal('value_0');
+        expect(result[1].text).to.equal('one');
+        expect(result[1].value).to.equal('value_1');
+        expect(result[2].text).to.equal('two');
+        expect(result[2].value).to.equal('value_2');
+        done();
+    });
+
+    it ('should return data as text and index as value', function(done) {
+        var data = [
+            {a: "zero", b: "value_0"},
+            {a: "one", b: "value_1"},
+            {a: "two", b: "value_2"},
+        ];
+
+        var result = ctx.ds.mapToTextValue({data: data});
+
+        expect(result).to.have.length(3);
+        expect(result[0].text).to.equal(data[0]);
+        expect(result[0].value).to.equal(0);
+        expect(result[1].text).to.equal(data[1]);
+        expect(result[1].value).to.equal(1);
+        expect(result[2].text).to.equal(data[2]);
+        expect(result[2].value).to.equal(2);
+        done();
+    });
 });

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -77,7 +77,8 @@ export class GenericDatasource {
 
   mapToTextValue(result) {
     return _.map(result.data, (d, i) => {
-      return { text: d, value: i};
+      if (d && d.text && d.value) return { text: d.text, value: d.value }
+      return { text: d, value: i };
     });
   }
 

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -62,8 +62,9 @@ export class GenericDatasource {
   }
 
   metricFindQuery(options) {
+    var target = typeof (options) == "string" ? options : options.target;
     var interpolated = {
-      target: this.templateSrv.replace(options.target, null, 'regex')
+        target: this.templateSrv.replace(target, null, 'regex')
     };
 
     return this.backendSrv.datasourceRequest({


### PR DESCRIPTION
This is related to issue #30.

Presently Simple JSON Datasource does not work as a proper data source for template variables of type: Query. It only supports an argument object with a property "target". When template variables send their query to the data source, there is only one argument and it is a string, which is just the content of the query the user entered into the template variable text box. 

Since `metricFindQuery` only expects a nested object as the argument, it effectively strips off the query value before sending it on to the data source when `options` is a string:

```
var interpolated = {
  target: this.templateSrv.replace(options.target, null, 'regex')
};
```

We can support both use cases by providing some conditional logic to detect what type of argument has been passed from Grafana:

```
var target = typeof (options) == "string" ? options : options.target;
var interpolated = {
  target: this.templateSrv.replace(target, null, 'regex')
};
```

Also right now the `mapToTextValue` function only supports results that are of a single value. The returned value is used as the text, and the index in the list is used as the value:

```
function mapToTextValue(result) {
  return _.map(result.data, function (d, i) {
    return { text: d, value: i };
  });
}
```

By adding some additional conditional logic to detect nested text/value objects, we can support both scenarios:

```
function mapToTextValue(result) {
  return _.map(result.data, function (d, i) {
    if (d && d.text && d.value) return { text: d.text, value: d.value }
    return { text: d, value: i };
  });
}
```

The nested `{ text: "label", value: "rawValue" }` is supported by query template variables. Grafana will use the `text` property as the label in the template variable drop down and the `value` property as the actual value of the template variable. I believe this also might possibly address issue #27 as well.

Using Simple JSON Datasource as a custom template variable aliasing solution is very desirable since Grafana currently does not support custom aliasing/look up for template variables. This happens when you have a raw value that is not very user-friendly to display that you want to use as a template variable. This setup provides a solution where you can use Simple JSON Datasource to alias template variables and provide a user-friendly label on the dashboard, but preserve the raw value for driving queries using your own HTTP endpoint to drive aliasing.
