### PR TITLE
Update packages and fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,29 +22,29 @@
   },
   "engineStrict": true,
   "devDependencies": {
-    "babel": "~6.5.1",
+    "babel": "^6.23.0",
     "chai": "~3.5.0",
-    "grunt": "~0.4.5",
+    "grunt": "^1.0.1",
     "grunt-babel": "~6.0.0",
     "grunt-cli": "^1.2.0",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-copy": "~0.8.2",
-    "grunt-contrib-uglify": "~0.11.0",
-    "grunt-contrib-watch": "^0.6.1",
+    "grunt-contrib-clean": "^1.1.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-uglify": "^2.3.0",
+    "grunt-contrib-watch": "^1.0.0",
     "grunt-execute": "~0.2.2",
-    "grunt-mocha-test": "~0.12.7",
-    "grunt-systemjs-builder": "^0.2.5",
-    "jsdom": "~3.1.2",
-    "load-grunt-tasks": "~3.2.0",
-    "prunk": "~1.2.1",
-    "q": "~1.4.1"
+    "grunt-mocha-test": "^0.13.2",
+    "grunt-systemjs-builder": "^1.0.0",
+    "jsdom": "~9.12.0",
+    "load-grunt-tasks": "^3.5.2",
+    "prunk": "^1.3.0",
+    "q": "^1.5.0"
   },
   "dependencies": {
     "babel-plugin-transform-es2015-for-of": "^6.6.0",
-    "babel-plugin-transform-es2015-modules-systemjs": "^6.5.0",
-    "babel-preset-es2015": "^6.5.0",
-    "lodash": "~4.0.0",
-    "mocha": "^2.4.5"
+    "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "lodash": "^4.17.4",
+    "mocha": "^3.2.0"
   },
   "homepage": "https://github.com/grafana/simple-json-datasource#readme"
 }

--- a/spec/test-main.js
+++ b/spec/test-main.js
@@ -13,8 +13,6 @@ prunk.mock('app/plugins/sdk', {
 // Required for loading angularjs
 global.document = jsdom('<html><head><script></script></head><body></body></html>');
 global.window = global.document.parentWindow;
-global.navigator = window.navigator = {};
-global.Node = window.Node;
 
 // Setup Chai
 chai.should();


### PR DESCRIPTION
My tests did not run because of some problems with `contextify` and then with `global.navigator`. Updating the packages and removing unused globals fixed the problem for me on node v7.8.0.

