### PR TITLE
Fix Query Editor: Replace self-closing textarea tag with closing tag

### DIFF
--- a/dist/partials/query.editor.html
+++ b/dist/partials/query.editor.html
@@ -5,7 +5,7 @@
     </div>
 
     <div class="gf-form" ng-if="ctrl.target.rawQuery">
-      <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()" />
+      <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()"></textarea>
     </div>
 
     <div ng-if="!ctrl.target.rawQuery">

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -5,7 +5,7 @@
     </div>
 
     <div class="gf-form" ng-if="ctrl.target.rawQuery">
-      <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()" />
+      <textarea class="gf-form-input" rows="5" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()"></textarea>
     </div>
 
     <div ng-if="!ctrl.target.rawQuery">


### PR DESCRIPTION
**What this PR does / why we need it:**
In Grafana 7+, we have done a jQuery Upgrade that breaks (changes) how jQuery parses html templates. It no longer replaces self-closing tags with closing tags. <textarea> had self-closing tag and this broke the query editor. More [here](https://github.com/grafana/simple-json-datasource/issues/155). Similar to https://github.com/grafana/grafana/pull/25889 and https://github.com/grafana/grafana/pull/26552.

**Without closed `<textarea>` tag:**
![image](https://user-images.githubusercontent.com/30407135/88299065-39b4cb80-cd02-11ea-8f2c-b1e823042f3c.png)

**With closed `<textarea>` tag:**
![image](https://user-images.githubusercontent.com/30407135/88298971-1db12a00-cd02-11ea-82b6-a1d42c783833.png)


Fixes: https://github.com/grafana/simple-json-datasource/issues/155