### PR TITLE
Docs: small docs patch to update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > - [JSON](https://grafana.com/grafana/plugins/simpod-json-datasource) by Šimon Podlipský
 > - [JSON API](https://grafana.com/grafana/plugins/marcusolsson-json-datasource) by Marcus Olsson
 
-More documentation about datasource plugins can be found in the [Docs](https://grafana.com/docs/grafana/latest/developers/plugins/).
+You can find more documentation about datasource plugins in Grafana's [Docs](https://grafana.com/docs/grafana/latest/developers/plugins/).
 
 This also serves as a living example implementation of a datasource.
 


### PR DESCRIPTION
This is a small and arbitrary patch to the README.

There is a broken URL on the website for this plugin:
https://grafana.com/grafana/plugins/grafana-simple-json-datasource/

The `Docs` link throws a 404. The proper link already appears in this repo.  I'm hoping to trigger a new CI build, from which we can publish a new release, which would push the fixed URL to the .com web page...?...